### PR TITLE
Upgrade to React 16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,10 @@
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
-    "rc-upload": "~2.1.0",
-    "react": "^15.3.2",
-    "react-dom": "^15.3.2"
+    "prop-types": "^15.6.1",
+    "rc-upload": "~2.4.4",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "babel": {
     "presets": [

--- a/src/Upload.js
+++ b/src/Upload.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import AjaxUploader from 'rc-upload/lib/AjaxUploader'
 import S3 from 'aws-sdk/clients/s3'
 


### PR DESCRIPTION
Thanks a lot for the wrapper, @edgji! I tried to use it on my project but I found it incompatible with React 16 since they moved `PropTypes` to its own package.

This upgrades the wrapper so it is compatible with React 16 along with bumping `rc-upload` to 2.4.4. This will allow this package to be used in projects that use React 16.

Do you think we can have this merged and published as new package version?